### PR TITLE
Prevent parallel execution of sftp checks on one host

### DIFF
--- a/sftp_check.go
+++ b/sftp_check.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -23,6 +24,8 @@ type SftpCheck struct {
 	hostKey      string
 	testfile     string
 	clientConfig *ssh.ClientConfig
+
+	mutex sync.Mutex
 }
 
 func NewSftpCheck(environmentID, checkID, name string, params map[string]string) (*SftpCheck, error) {
@@ -65,6 +68,9 @@ func NewSftpCheck(environmentID, checkID, name string, params map[string]string)
 }
 
 func (c *SftpCheck) Check() []Result {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
 	mainResult := NewResult(c.environmentID, c.checkID, c.name)
 
 	var err error

--- a/sftp_check.go
+++ b/sftp_check.go
@@ -2,43 +2,37 @@ package main
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/pkg/errors"
 	"github.com/pkg/sftp"
 	"golang.org/x/crypto/ssh"
-	"time"
 )
 
 type SftpCheck struct {
-	environmentId string
-	checkId       string
+	environmentID string
+	checkID       string
 	name          string
 
-	timeout  time.Duration
-	host     string
-	port     string
-	user     string
-	password string
-	key      string
-	hostKey  string
-	testfile string
+	timeout      time.Duration
+	host         string
+	port         string
+	user         string
+	password     string
+	key          string
+	hostKey      string
+	testfile     string
+	clientConfig *ssh.ClientConfig
 }
 
-func NewSftpCheck(environmentId, checkId, name string, params map[string]string) (*SftpCheck, error) {
+func NewSftpCheck(environmentID, checkID, name string, params map[string]string) (*SftpCheck, error) {
 	c := &SftpCheck{
-		environmentId: environmentId,
-		checkId:       checkId,
+		environmentID: environmentID,
+		checkID:       checkID,
 		name:          name,
 		host:          params["host"],
 		port:          params["port"],
-		user:          params["user"],
-		password:      params["password"],
-		key:           params["key"],
-		hostKey:       params["hostKey"],
 		testfile:      params["testfile"],
-	}
-
-	if c.password == "" && c.key == "" {
-		return nil, fmt.Errorf("password or key have to be supplied")
 	}
 
 	if t, exist := params["timeout"]; exist {
@@ -55,11 +49,23 @@ func NewSftpCheck(environmentId, checkId, name string, params map[string]string)
 		c.port = "22"
 	}
 
+	clientConfig, err := createSSHClientConfig(
+		params["user"],
+		params["key"],
+		params["password"],
+		params["hostKey"],
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	c.clientConfig = clientConfig
+
 	return c, nil
 }
 
 func (c *SftpCheck) Check() []Result {
-	mainResult := NewResult(c.environmentId, c.checkId, c.name)
+	mainResult := NewResult(c.environmentID, c.checkID, c.name)
 
 	var err error
 	done := make(chan bool, 1)
@@ -87,67 +93,89 @@ func (c *SftpCheck) Check() []Result {
 }
 
 func (c *SftpCheck) connectTest() error {
-
-	var authMethod ssh.AuthMethod
-	if c.key != "" {
-		signer, err := ssh.ParsePrivateKey([]byte(c.key))
-		if err != nil {
-			return errors.Wrap(err, "unable to parse private key")
-		}
-		authMethod = ssh.PublicKeys(signer)
-	} else {
-		authMethod = ssh.Password(c.password)
-	}
-
-	var hostKeyVerification ssh.HostKeyCallback
-	if c.hostKey != "" {
-		hostKey, _, _, _, err := ssh.ParseAuthorizedKey([]byte(c.hostKey))
-		if err != nil {
-			return errors.Wrap(err, "unable to parse host key")
-		}
-		hostKeyVerification = ssh.FixedHostKey(hostKey)
-	} else {
-		hostKeyVerification = ssh.InsecureIgnoreHostKey()
-	}
-
-	config := &ssh.ClientConfig{
-		User:            c.user,
-		Auth:            []ssh.AuthMethod{authMethod},
-		HostKeyCallback: hostKeyVerification,
-	}
-	conn, err := ssh.Dial("tcp", c.host+":"+c.port, config)
+	conn, err := ssh.Dial("tcp", c.host+":"+c.port, c.clientConfig)
 	if err != nil {
 		return errors.Wrap(err, "failed to connect with ssh")
 	}
 	defer conn.Close()
 
-	sftp, err := sftp.NewClient(conn)
+	client, err := sftp.NewClient(conn)
 	if err != nil {
 		return errors.Wrap(err, "can't create sftp client")
 	}
-	defer sftp.Close()
+	defer client.Close()
 
 	// Check if we can create a file
 	if c.testfile != "" {
-		f, err := sftp.Create(c.testfile)
-		if err != nil {
-			return errors.Wrap(err, "can not create testfile")
-		}
-		if _, err := f.Write([]byte("Healthcheck")); err != nil {
-			return errors.Wrap(err, "can not write to testfile")
-		}
-		f.Close()
-
-		_, err = sftp.Lstat(c.testfile)
-		if err != nil {
-			return errors.Wrap(err, "testfile not there")
-		}
-
-		err = sftp.Remove(c.testfile)
-		if err != nil {
-			return errors.Wrap(err, "can not remove testfile")
-		}
+		return c.checkFileCreation(client)
 	}
 
 	return nil
+}
+
+func (c *SftpCheck) checkFileCreation(client *sftp.Client) error {
+	f, err := client.Create(c.testfile)
+	if err != nil {
+		return errors.Wrap(err, "can not create testfile")
+	}
+	if _, err := f.Write([]byte("Healthcheck")); err != nil {
+		return errors.Wrap(err, "can not write to testfile")
+	}
+	f.Close()
+
+	_, err = client.Lstat(c.testfile)
+	if err != nil {
+		return errors.Wrap(err, "testfile not there")
+	}
+
+	err = client.Remove(c.testfile)
+	if err != nil {
+		return errors.Wrap(err, "can not remove testfile")
+	}
+	return nil
+}
+
+func createSSHClientConfig(user, key, password, hostKey string) (*ssh.ClientConfig, error) {
+	if password == "" && key == "" {
+		return nil, fmt.Errorf("password or key have to be supplied")
+	}
+
+	authMethod, err := selectAuthMethod(key, password)
+	if err != nil {
+		return nil, err
+	}
+	hostKeyVerification, err := selectHostKeyVerification(hostKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ssh.ClientConfig{
+		User:            user,
+		Auth:            []ssh.AuthMethod{authMethod},
+		HostKeyCallback: hostKeyVerification,
+	}, nil
+}
+
+func selectAuthMethod(key, password string) (ssh.AuthMethod, error) {
+	if key != "" {
+		signer, err := ssh.ParsePrivateKey([]byte(key))
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to parse private key")
+		}
+		return ssh.PublicKeys(signer), nil
+	}
+
+	return ssh.Password(password), nil
+}
+
+func selectHostKeyVerification(hostKey string) (ssh.HostKeyCallback, error) {
+	if hostKey != "" {
+		hostKey, _, _, _, err := ssh.ParseAuthorizedKey([]byte(hostKey))
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to parse host key")
+		}
+		return ssh.FixedHostKey(hostKey), nil
+	}
+
+	return ssh.InsecureIgnoreHostKey(), nil
 }


### PR DESCRIPTION
The sftp check occasionally errors with the message `ssh: handshake failed: EOF`. This can be caused by by connecting to a host in parallel. This commit introduces a `sync.Mutex` in the `SftpCheck` to prevent parallel execution.